### PR TITLE
Removal of 'How It Works' from nav bar

### DIFF
--- a/application/views/twigs/template.twig
+++ b/application/views/twigs/template.twig
@@ -51,9 +51,6 @@
 				<div class="collapse navbar-collapse justify-content-between" id="navbar-collapse">
 					<ul class="navbar-nav">
 						<li class="nav-item mr-2">
-							<a class="nav-link" href="/home">How It Works</a>
-						</li>
-						<li class="nav-item mr-2">
 							<a class="nav-link" href="/products">Available Products</a>
 						</li>
 						<li class="nav-item mr-2">


### PR DESCRIPTION
Front-page already contains an explanation of how the website works, and separate nav bar item is not needed